### PR TITLE
Add OLED Black Theme

### DIFF
--- a/assets/romfs/themes/oled_black_theme.ini
+++ b/assets/romfs/themes/oled_black_theme.ini
@@ -1,0 +1,23 @@
+[meta]
+name=OLED Black
+author=iTotalJustice/Sanras
+version=1.0.0
+preview=romfs:/theme/preview.jpg
+
+[theme]
+background=0x000000ff
+cursor=romfs:/theme/cursor.png
+cursor_drag=romfs:/theme/cursor_drag.png
+grid=0x46464640
+selected=0x323232ff
+selected_overlay=0x00ffc8ff
+text=0xfbfbfbff
+text_selected=0x00ffc8ff
+
+icon_audio=romfs:/theme/icon_audio.png
+icon_video=romfs:/theme/icon_video.png
+icon_image=romfs:/theme/icon_image.png
+icon_file=romfs:/theme/icon_file.png
+icon_folder=romfs:/theme/icon_folder.png
+icon_zip=romfs:/theme/icon_zip.png
+icon_nro=romfs:/theme/icon_nro.png


### PR DESCRIPTION
Created a new theme .ini file, based off of `Black` theme. Makes background black and adjusts selection colors.

![HBMenuNX_20241217_162707_00](https://github.com/user-attachments/assets/7961058c-adc2-4155-afdb-efc2d0eecf71)