### PR TITLE
Improvement with Daybreak detection

### DIFF
--- a/sphaira/include/nro.hpp
+++ b/sphaira/include/nro.hpp
@@ -76,4 +76,6 @@ auto nro_add_arg_file(std::string arg) -> std::string;
 // strips sdmc:
 auto nro_normalise_path(const std::string& p) -> std::string;
 
+auto SearchHomebrew(const char* name) -> NroEntry;
+
 } // namespace sphaira

--- a/sphaira/include/nro.hpp
+++ b/sphaira/include/nro.hpp
@@ -76,6 +76,6 @@ auto nro_add_arg_file(std::string arg) -> std::string;
 // strips sdmc:
 auto nro_normalise_path(const std::string& p) -> std::string;
 
-auto SearchHomebrew(const char* name) -> NroEntry;
+auto search_homebrew(const char* name) -> NroEntry;
 
 } // namespace sphaira

--- a/sphaira/include/nro.hpp
+++ b/sphaira/include/nro.hpp
@@ -76,6 +76,6 @@ auto nro_add_arg_file(std::string arg) -> std::string;
 // strips sdmc:
 auto nro_normalise_path(const std::string& p) -> std::string;
 
-auto search_homebrew(const char* name) -> NroEntry;
+auto search_homebrew(const std::vector<NroEntry> m_entries, const char* name, const fs::FsPath path = "") -> NroEntry;
 
 } // namespace sphaira

--- a/sphaira/source/nro.cpp
+++ b/sphaira/source/nro.cpp
@@ -309,7 +309,7 @@ auto nro_normalise_path(const std::string& p) -> std::string {
     return p;
 }
 
-auto SearchHomebrew(const char* name) -> NroEntry {
+auto search_homebrew(const char* name) -> NroEntry {
     std::vector<NroEntry> m_entries;
     nro_scan("/switch", m_entries, false);
     for (auto& p : m_entries) {

--- a/sphaira/source/nro.cpp
+++ b/sphaira/source/nro.cpp
@@ -309,12 +309,16 @@ auto nro_normalise_path(const std::string& p) -> std::string {
     return p;
 }
 
-auto search_homebrew(const char* name) -> NroEntry {
-    std::vector<NroEntry> m_entries;
-    nro_scan("/switch", m_entries, false);
+auto search_homebrew(const std::vector<NroEntry> m_entries, const char* name, const fs::FsPath path) -> NroEntry {
     for (auto& p : m_entries) {
-        if (!std::strcmp(p.nacp.lang[0].name, name)) {
-            return p;
+        if (path == "") {
+            if (!std::strcmp(p.nacp.lang[0].name, name)) {
+                return p;
+            }
+        } else {
+            if (!std::strcmp(p.path.s, path.s) && !std::strcmp(p.nacp.lang[0].name, name)) {
+                return p;
+            }
         }
     }
     return {};

--- a/sphaira/source/nro.cpp
+++ b/sphaira/source/nro.cpp
@@ -309,4 +309,15 @@ auto nro_normalise_path(const std::string& p) -> std::string {
     return p;
 }
 
+auto SearchHomebrew(const char* name) -> NroEntry {
+    std::vector<NroEntry> m_entries;
+    nro_scan("/switch", m_entries, false);
+    for (auto& p : m_entries) {
+        if (!std::strcmp(p.nacp.lang[0].name, name)) {
+            return p;
+        }
+    }
+    return {};
+}
+
 } // namespace sphaira

--- a/sphaira/source/ui/menus/filebrowser.cpp
+++ b/sphaira/source/ui/menus/filebrowser.cpp
@@ -105,7 +105,7 @@ constexpr RomDatabaseEntry PATHS[]{
     { "wonderswancolor", "Bandai - WonderSwan Color"},
 };
 
-NroEntry DAYBREAKENTRY = search_homebrew("Daybreak");
+NroEntry DAYBREAKENTRY = {};
 
 constexpr const char* SORT_STR[] = {
     "Size",
@@ -252,7 +252,7 @@ auto GetRomIcon(ProgressBox* pbox, std::string filename, std::string extension, 
 }
 
 // returns 0 if true
-auto CheckIfUpdateFolder(const fs::FsPath& path, std::span<FileEntry> entries) -> Result {
+auto CheckIfUpdateFolder(const fs::FsPath& path, std::span<FileEntry> entries, const std::vector<NroEntry> nros) -> Result {
     fs::FsNativeSd fs;
     R_TRY(fs.GetFsOpenResult());
 
@@ -260,7 +260,11 @@ auto CheckIfUpdateFolder(const fs::FsPath& path, std::span<FileEntry> entries) -
     NacpStruct nacp;
     Result rc = nro_get_nacp(DAYBREAKENTRY.path, nacp);
     if ((R_SUCCEEDED(rc) && std::strcmp(DAYBREAKENTRY.nacp.lang[0].name, "Daybreak")) || R_FAILED(rc)) {
-        DAYBREAKENTRY = search_homebrew("daybreak");
+        DAYBREAKENTRY = search_homebrew(nros, "Daybreak", "/switch/daybreak.nro");
+        rc = nro_get_nacp(DAYBREAKENTRY.path, nacp);
+        if ((R_SUCCEEDED(rc) && std::strcmp(DAYBREAKENTRY.nacp.lang[0].name, "Daybreak")) || R_FAILED(rc)) {
+            DAYBREAKENTRY = search_homebrew(nros, "Daybreak");
+        }
     }
 	R_UNLESS(fs.FileExists(DAYBREAKENTRY.path) && !std::strcmp(DAYBREAKENTRY.nacp.lang[0].name, "Daybreak"), 0x1);
 
@@ -964,7 +968,7 @@ auto Menu::Scan(const fs::FsPath& new_path, bool is_walk_up) -> Result {
     Sort();
 
     // quick check to see if this is an update folder
-    m_is_update_folder = R_SUCCEEDED(CheckIfUpdateFolder(new_path, m_entries));
+    m_is_update_folder = R_SUCCEEDED(CheckIfUpdateFolder(new_path, m_entries, m_nro_entries));
 
     SetIndex(0);
 

--- a/sphaira/source/ui/menus/filebrowser.cpp
+++ b/sphaira/source/ui/menus/filebrowser.cpp
@@ -105,7 +105,7 @@ constexpr RomDatabaseEntry PATHS[]{
     { "wonderswancolor", "Bandai - WonderSwan Color"},
 };
 
-constexpr fs::FsPath DAYBREAK_PATH{"/switch/daybreak.nro"};
+NroEntry DAYBREAKENTRY = SearchHomebrew("Daybreak");
 
 constexpr const char* SORT_STR[] = {
     "Size",
@@ -257,7 +257,12 @@ auto CheckIfUpdateFolder(const fs::FsPath& path, std::span<FileEntry> entries) -
     R_TRY(fs.GetFsOpenResult());
 
     // check that we have daybreak installed
-    R_UNLESS(fs.FileExists(DAYBREAK_PATH), FsError_FileNotFound);
+    NacpStruct nacp;
+    Result rc = nro_get_nacp(DAYBREAKENTRY.path, nacp);
+    if ((R_SUCCEEDED(rc) && std::strcmp(DAYBREAKENTRY.nacp.lang[0].name, "Daybreak")) || R_FAILED(rc)) {
+        DAYBREAKENTRY = SearchHomebrew("daybreak");
+    }
+	R_UNLESS(fs.FileExists(DAYBREAKENTRY.path) && !std::strcmp(DAYBREAKENTRY.nacp.lang[0].name, "Daybreak"), 0x1);
 
     FsDir d;
     R_TRY(fs.OpenDirectory(path, FsDirOpenMode_ReadDirs, &d));
@@ -384,7 +389,7 @@ Menu::Menu(const std::vector<NroEntry>& nro_entries) : MenuBase{"FileBrowser"_i1
                     if (op_index && *op_index) {
                         // daybreak uses native fs so do not use nro_add_arg_file
                         // otherwise it'll fail to open the folder...
-                        nro_launch(DAYBREAK_PATH, nro_add_arg(m_path));
+                        nro_launch(DAYBREAKENTRY.path, nro_add_arg(m_path));
                     }
                 }));
                 return;

--- a/sphaira/source/ui/menus/filebrowser.cpp
+++ b/sphaira/source/ui/menus/filebrowser.cpp
@@ -105,7 +105,7 @@ constexpr RomDatabaseEntry PATHS[]{
     { "wonderswancolor", "Bandai - WonderSwan Color"},
 };
 
-NroEntry DAYBREAKENTRY = SearchHomebrew("Daybreak");
+NroEntry DAYBREAKENTRY = search_homebrew("Daybreak");
 
 constexpr const char* SORT_STR[] = {
     "Size",
@@ -260,7 +260,7 @@ auto CheckIfUpdateFolder(const fs::FsPath& path, std::span<FileEntry> entries) -
     NacpStruct nacp;
     Result rc = nro_get_nacp(DAYBREAKENTRY.path, nacp);
     if ((R_SUCCEEDED(rc) && std::strcmp(DAYBREAKENTRY.nacp.lang[0].name, "Daybreak")) || R_FAILED(rc)) {
-        DAYBREAKENTRY = SearchHomebrew("daybreak");
+        DAYBREAKENTRY = search_homebrew("daybreak");
     }
 	R_UNLESS(fs.FileExists(DAYBREAKENTRY.path) && !std::strcmp(DAYBREAKENTRY.nacp.lang[0].name, "Daybreak"), 0x1);
 


### PR DESCRIPTION
I've changed how Daybreak is detected, personnaly it is in "/switch/daybreak/daybreak.nro" cause I prefer to not place NROs directly in my "/switch" folder. It is effectivly slower than before but I've tried to minimize the impact of the modification and for me it's better cause it doesn't force a specific config for this function to work except having Daybreak correctly set in the homebrews list.
Like I've said in a previous issue I have a Daybreak implementation in one of my homebrew witch could be easily integrated in Sphaira with some smalls modifications, if you want I can try to do it? Or do you plan to make your own implementation of this yourself?