### PR TITLE
Trying update app fix

### DIFF
--- a/sphaira/source/ui/menus/main_menu.cpp
+++ b/sphaira/source/ui/menus/main_menu.cpp
@@ -89,6 +89,10 @@ auto InstallUpdate(ProgressBox* pbox, const std::string url, const std::string v
                 file_path = fs::AppendPath("/", file_path);
             }
 
+            if (!strcasecmp(strrchr(file_path.s, '/'), "/sphaira.nro")) {
+                file_path = App::GetExePath();
+            }
+
             Result rc;
             if (file_path[strlen(file_path) -1] == '/') {
                 if (R_FAILED(rc = fs.CreateDirectoryRecursively(file_path)) && rc != FsError_PathAlreadyExists) {


### PR DESCRIPTION
Tried to fix updating the app in some circonstances (if the nro of Sphaira is in a non standard path or even if it is in "/switch/sphaira.nro") and modifying some logs messages. It's a realy simple approach but it should works in most cases.
I've also modified how Sphaira could replace "/hbmenu.nro" if it's launched as HBMenu cause update process of the app could now replace "/hbmenu.nro" and if version downloaded by the update is more recent than the one present in "/switch/sphaira.nro" or "/switch/sphaira/sphaira.nro" they can replace the updated version, I've supposed that it is not what we want.