### PR TITLE
Added 12 hour clock to main menu

### DIFF
--- a/sphaira/include/app.hpp
+++ b/sphaira/include/app.hpp
@@ -79,6 +79,7 @@ public:
     static auto GetInstallPrompt() -> bool;
     static auto GetThemeShuffleEnable() -> bool;
     static auto GetThemeMusicEnable() -> bool;
+    static auto Get12HourTimeEnable() -> bool;
     static auto GetLanguage() -> long;
     static auto GetTextScrollSpeed() -> long;
 
@@ -92,6 +93,7 @@ public:
     static void SetInstallPrompt(bool enable);
     static void SetThemeShuffleEnable(bool enable);
     static void SetThemeMusicEnable(bool enable);
+    static void Set12HourTimeEnable(bool enable);
     static void SetLanguage(long index);
     static void SetTextScrollSpeed(long index);
 
@@ -177,6 +179,7 @@ public:
     option::OptionLong m_install_prompt{INI_SECTION, "install_prompt", true};
     option::OptionBool m_theme_shuffle{INI_SECTION, "theme_shuffle", false};
     option::OptionBool m_theme_music{INI_SECTION, "theme_music", true};
+    option::OptionBool m_12hour_time{INI_SECTION, "12hour_time", false};
     option::OptionLong m_language{INI_SECTION, "language", 0}; // auto
     // todo: move this into it's own menu
     option::OptionLong m_text_scroll_speed{"accessibility", "text_scroll_speed", 1}; // normal

--- a/sphaira/source/app.cpp
+++ b/sphaira/source/app.cpp
@@ -604,6 +604,10 @@ auto App::GetTextScrollSpeed() -> long {
     return g_app->m_text_scroll_speed.Get();
 }
 
+auto App::Get12HourTimeEnable() -> bool {
+    return g_app->m_12hour_time.Get();
+}
+
 void App::SetNxlinkEnable(bool enable) {
     if (App::GetNxlinkEnable() != enable) {
         g_app->m_nxlink_enabled.Set(enable);
@@ -744,6 +748,10 @@ void App::SetThemeShuffleEnable(bool enable) {
 void App::SetThemeMusicEnable(bool enable) {
     g_app->m_theme_music.Set(enable);
     PlaySoundEffect(SoundEffect::SoundEffect_Music);
+}
+
+void App::Set12HourTimeEnable(bool enable) {
+    g_app->m_12hour_time.Set(enable);
 }
 
 void App::SetMtpEnable(bool enable) {

--- a/sphaira/source/ui/menus/main_menu.cpp
+++ b/sphaira/source/ui/menus/main_menu.cpp
@@ -253,6 +253,10 @@ MainMenu::MainMenu() {
                 options->Add(std::make_shared<SidebarEntryBool>("Music"_i18n, App::GetThemeMusicEnable(), [this](bool& enable){
                     App::SetThemeMusicEnable(enable);
                 }, "Enabled"_i18n, "Disabled"_i18n));
+
+                options->Add(std::make_shared<SidebarEntryBool>("12 Hour Time"_i18n, App::Get12HourTimeEnable(), [this](bool& enable){
+                    App::Set12HourTimeEnable(enable);
+                }, "Enabled"_i18n, "Disabled"_i18n));
             }));
 
             options->Add(std::make_shared<SidebarEntryCallback>("Network"_i18n, [this](){

--- a/sphaira/source/ui/menus/menu_base.cpp
+++ b/sphaira/source/ui/menus/menu_base.cpp
@@ -46,7 +46,13 @@ void MenuBase::Draw(NVGcontext* vg, Theme* theme) {
 
     // draw("version %s", APP_VERSION);
     draw(ThemeEntryID_TEXT, "%u\uFE6A", m_battery_percetange);
-    draw(ThemeEntryID_TEXT, "%02u:%02u:%02u", m_tm.tm_hour, m_tm.tm_min, m_tm.tm_sec);
+
+    if (App::Get12HourTimeEnable()) {
+        draw(ThemeEntryID_TEXT, "%02u:%02u:%02u %s", (m_tm.tm_hour == 0 || m_tm.tm_hour == 12) ? 12 : m_tm.tm_hour % 12, m_tm.tm_min, m_tm.tm_sec, (m_tm.tm_hour < 12) ? "AM" : "PM");
+    } else {
+        draw(ThemeEntryID_TEXT, "%02u:%02u:%02u", m_tm.tm_hour, m_tm.tm_min, m_tm.tm_sec);
+    }
+
     if (m_ip) {
         draw(ThemeEntryID_TEXT, "%u.%u.%u.%u", m_ip&0xFF, (m_ip>>8)&0xFF, (m_ip>>16)&0xFF, (m_ip>>24)&0xFF);
     } else {


### PR DESCRIPTION
Makes the clock on the main menu be formatted for 12 hour time with AM/PM instead of 24 hour time, and adds a toggle in the theme menu to turn it on (24 hour is still default) 

![2025 02 18_230824](https://github.com/user-attachments/assets/1074b94f-f328-43ce-8371-0266b59a211a)

![2025 02 18_230821](https://github.com/user-attachments/assets/2521b2da-ffac-4e3f-bf1d-fd2cde1e9ebf)
